### PR TITLE
[WPApi] refactor args annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,98 @@ Based on https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-
 
 Supposed we want this endpoint `https://domain.test/wp-json/questions/v1/questions-by-user?page=1` the annotation would be :
 - **namespace** : corresponding `questions`
-- **version** : corresponding to `v1`, we can maintain different api version by incrementing the version and keeping the same endpoint url
+- **version** : corresponding to `v1`, we can maintain different api version by incrementing the version and keeping the same endpoint url (default to `v1`)
 - **url** : corresponding to `questions-by-user`, can include dynamic parameters according to wordpress documentation (example `/author/(?P<id>\d+)`)
-- **method** : corresponding to HTTP verb `GET`, `POST` etc
-- **args** : corresponding to (example `?page=1`) request arguments : [doc](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#arguments)
+- **args** : corresponding to third parameter of `register_rest_route` function : [doc](https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#arguments)
+
+```php
+
+ class QuestionApiService extends AbstractApiService
+{
+    /**
+     * @WPApiEndpoint(
+     *     namespace = "questions",
+     *     version = "v1",
+     *     url = "/questions-by-user",
+     *     args = {
+    *       "methods": "GET",
+    *       "args": {
+    *           "page": {
+    *               "default": 1,
+    *               "sanitize_callback": "convertToInt"
+    *           }, 
+    *           "limit": {
+    *               "default": 1,
+    *               "sanitize_callback": "convertToInt"
+    *           }
+    *       },
+    *       "permission_callback": "canFetchQuestions"
+    *     }
+     * )
+     */
+    public function questionsByUser(WP_REST_Request $request)
+    {
+        $page = $request->get_param('page');
+        
+        /* Processing get questions */
+        
+        // To handle error we can return WP_Error instance
+        return WP_Error('error_code', 'Error message', ['status' => 400]);
+    
+        // Or success response
+        return new WP_REST_Response([
+            'questions' => [],
+        ]);
+    }
+    
+    public function canFetchQuestions(WP_REST_Request $request) 
+    {
+        $user = wp_get_current_user();
+        
+        /* processing verification */
+        
+        return true;
+    }
+    
+    public function convertToInt($param, $request, $key)
+    {
+        /* Processing sanitize method */
+        return (int) $param;
+    }
+}
+```
+
+The namespace could be define globaly.
+For example to create this endpoint `https://domain.test/wp-json/questions/v1/delete-question/1` 
 
 ```php
 /**
- * @WPApiEndpoint(
- *     namespace = "questions",
- *     version = "v1",
- *     url = "/questions-by-user",
- *     method = "GET",
- *     args = {"page": {"default": 1}, "limit": {"default": 1}}
+ * @WPApiNamespace(
+ *     namespace="questions"
  * )
  */
-public function questionsByUser(WP_REST_Request $request)
+class QuestionApiService extends AbstractApiService
 {
-    $userId = $request->get_param('userId');
+/**
+     * @WPApiEndpoint(
+     *     url = "/delete-question/(?P<id>\d+)",
+     *     args = {
+     *      "methods": "DELETE",
+     *      "permission_callback": "canDeleteQuestion"
+     *     }
+     * )
+     */
+    public function deleteQuestion(WP_REST_Request $request)
+    {
+        /* Processing deletion */
+    }
     
-    /* ... */
-
-    return new WP_REST_Response([
-        'questions' => [],
-    ]);
+    public function canDeleteQuestion()
+    {}
 }
 ```
+
+### Important notice
+
+For `sanitize_callback`, `validate_callback` and `permission_callback`, we are looking for an instance method on the same class of the annotation.
+In second time, we look for a global function.

--- a/README.md
+++ b/README.md
@@ -99,5 +99,5 @@ class QuestionApiService extends AbstractApiService
 
 ### Important notice
 
-For `sanitize_callback`, `validate_callback` and `permission_callback`, we are looking for an instance method on the same class of the annotation.
+Because we cannot reference `$this` from within an annotation, for any callback function specified inside a @WPApiEndpoint annotation, be it `sanitize_callback`, `validate_callback`, `permission_callback` and so on, the provided callback name (for example `myFunction`), is first looked for on the same class instance than the method carrying out the annotation. If not found there, it's then looked for on the global namespace (like a function name)
 In second time, we look for a global function.

--- a/src/AbstractApiService.php
+++ b/src/AbstractApiService.php
@@ -2,21 +2,24 @@
 
 namespace WonderWp\Component\API;
 
+use Doctrine\Common\Annotations\AnnotationException;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use WonderWp\Component\API\Annotation\WPApiEndpoint;
+use WonderWp\Component\API\Annotation\WPApiNamespace;
 use WonderWp\Component\HttpFoundation\Request;
 use WonderWp\Component\HttpFoundation\Result;
 use WonderWp\Component\Service\AbstractService;
-use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\AnnotationRegistry;
 
 abstract class AbstractApiService extends AbstractService implements ApiServiceInterface
 {
     /** @var Request */
     protected $request;
 
-    protected function enableErrors(){
+    protected function enableErrors()
+    {
         error_reporting(E_ALL);
-        ini_set('display_errors','on');
+        ini_set('display_errors', 'on');
     }
 
     /** @inheritdoc */
@@ -31,10 +34,12 @@ abstract class AbstractApiService extends AbstractService implements ApiServiceI
         $methods = $this->listEndPoints();
         foreach ($methods as $method) {
 
+            $apiNamespaceAnnotation = $reader->getClassAnnotation($reflection, WPApiNamespace::class);
+
             $apiEndpointAnnotation = $reader->getMethodAnnotation($reflection->getMethod($method), WPApiEndpoint::class);
 
             if ($apiEndpointAnnotation !== null) {
-                $this->registerWPApiEndpoint($apiEndpointAnnotation, $reflection->getName(), $method);
+                $this->registerWPApiEndpoint($apiNamespaceAnnotation, $apiEndpointAnnotation, $reflection->getName(), $method);
             } else {
                 $this->registerAdminEndpoint($className, $method);
             }
@@ -42,7 +47,8 @@ abstract class AbstractApiService extends AbstractService implements ApiServiceI
         return $methods;
     }
 
-    protected function executeEndPoint($method){
+    protected function executeEndPoint($method)
+    {
         $this->setRequest(Request::getInstance());
         call_user_func([$this, $method]);
         wp_die();
@@ -51,9 +57,10 @@ abstract class AbstractApiService extends AbstractService implements ApiServiceI
     /**
      * @return array
      */
-    protected function listEndPoints(){
-        $exclude   = ['__construct', 'registerEndpoints','listEndPoints'];
-        $methods   = array_diff(get_class_methods($this), $exclude);
+    protected function listEndPoints()
+    {
+        $exclude = ['__construct', 'registerEndpoints', 'listEndPoints'];
+        $methods = array_diff(get_class_methods($this), $exclude);
         return $methods;
     }
 
@@ -75,7 +82,7 @@ abstract class AbstractApiService extends AbstractService implements ApiServiceI
     public function respond(Result $result, $format = 'json')
     {
         if ($format === 'json') {
-            if(!headers_sent()){
+            if (!headers_sent()) {
                 header('Content-Type: application/json');
             }
             echo $result;
@@ -98,24 +105,34 @@ abstract class AbstractApiService extends AbstractService implements ApiServiceI
         }
     }
 
-    protected function registerWPApiEndpoint(WPApiEndpoint $apiEndpointAnnotation, $className, $method) {
-        add_action( 'rest_api_init', function () use ($apiEndpointAnnotation, $className, $method) {
-            $namespace = $apiEndpointAnnotation->namespace.'/'.$apiEndpointAnnotation->version;
+    protected function registerWPApiEndpoint(WPApiNamespace $apiNamespaceAnnotation, WPApiEndpoint $apiEndpointAnnotation, $className, $method)
+    {
+        add_action('rest_api_init', function () use ($apiNamespaceAnnotation, $apiEndpointAnnotation, $className, $method) {
+            $namespace = '';
+
+            if ($apiEndpointAnnotation->namespace) {
+                $namespace = $apiEndpointAnnotation->namespace;
+            } else if ($apiNamespaceAnnotation->namespace) {
+                $namespace = $apiNamespaceAnnotation->namespace;
+            } else {
+                throw new AnnotationException('Missing namespace');
+            }
+
+            $namespaceAndVersion = $namespace . '/' . $apiEndpointAnnotation->version;
             $handler = [$this, $method];
 
-            register_rest_route( $namespace, $apiEndpointAnnotation->url, [
-                'methods' => $apiEndpointAnnotation->method,
-                'callback' => $handler,
-                'args' => $apiEndpointAnnotation->args
-            ] );
-        } );
+            $computedArgs = $this->recursiveBuildCallable($apiEndpointAnnotation->args);
+            $computedArgs['callback'] = $handler;
+
+            register_rest_route($namespaceAndVersion, $apiEndpointAnnotation->url, $computedArgs);
+        });
     }
 
     /**
      * @param string $className
      * @param $method
      */
-    protected function registerAdminEndpoint( $className, $method)
+    protected function registerAdminEndpoint($className, $method)
     {
         add_action('wp_ajax_' . $className . '.' . $method, function () use ($method) {
             $this->executeEndPoint($method);
@@ -124,5 +141,21 @@ abstract class AbstractApiService extends AbstractService implements ApiServiceI
         add_action('wp_ajax_nopriv_' . $className . '.' . $method, function () use ($method) {
             $this->executeEndPoint($method);
         });
+    }
+
+    private function recursiveBuildCallable($args = []) {
+        foreach ($args as $param => $arg) {
+            if (is_array($arg)) {
+                $args[$param] = $this->recursiveBuildCallable($arg);
+            }
+
+            if (strpos($param, '_callback') !== false) {
+                if (method_exists($this, $arg)) {
+                    $args[$param] = [$this, $arg];
+                }
+            }
+        }
+
+        return $args;
     }
 }

--- a/src/Annotation/WPApiEndpoint.php
+++ b/src/Annotation/WPApiEndpoint.php
@@ -2,6 +2,7 @@
 
 namespace WonderWp\Component\API\Annotation;
 
+
 /**
  * @Annotation
  * @Target({"METHOD"})
@@ -9,7 +10,6 @@ namespace WonderWp\Component\API\Annotation;
 class WPApiEndpoint
 {
     /**
-     * @Required
      * @var string
      */
     public $namespace;
@@ -24,12 +24,6 @@ class WPApiEndpoint
      * @var string
      */
     public $url;
-
-    /**
-     * @Required
-     * @var string
-     */
-    public $method;
 
     /**
      * @var array

--- a/src/Annotation/WPApiNamespace.php
+++ b/src/Annotation/WPApiNamespace.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WonderWp\Component\API\Annotation;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ */
+class WPApiNamespace
+{
+    /**
+     * @var string
+     */
+    public $namespace;
+}


### PR DESCRIPTION
Permet d'ajouter un le `permission_callback` lors de l'enregistrement d'un endpoint wordpress.